### PR TITLE
Cli errormsg

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -48,7 +48,6 @@ class Ctrl{
     void updateCalculationStatus();
 
     void displayErrorMessage(const int);
-    void printErrorMessage(const int);
     // unit tests
     bool unittestExcluded();
     bool unittestProtein();

--- a/include/controller.h
+++ b/include/controller.h
@@ -47,7 +47,7 @@ class Ctrl{
     bool getAbortFlag();
     void updateCalculationStatus();
 
-    void displayErrorMessage(const int);
+    void displayErrorMessage(const int, const std::vector<std::string>& =std::vector<std::string>());
     // unit tests
     bool unittestExcluded();
     bool unittestProtein();

--- a/src/base_cmdline.cpp
+++ b/src/base_cmdline.cpp
@@ -39,7 +39,7 @@ static const wxCmdLineEntryDesc s_cmd_line_desc[] =
   { wxCMD_LINE_NONE }
 };
 
-static const std::vector<std::string> s_required_args = {"r", "g", "fs"};
+static const std::vector<std::string> s_required_args = {"radius", "grid", "file-structure"};
 
 bool validateProbes(const double, const double, const bool);
 bool validateExport(const std::string, const std::vector<bool>);

--- a/src/base_cmdline.cpp
+++ b/src/base_cmdline.cpp
@@ -90,7 +90,7 @@ void MainApp::evalCmdLine(){
     return;
   }
   // check if all required arguments are available
-  for (auto& arg_name : s_required_args){
+  for (const std::string& arg_name : s_required_args){
     if (!parser.Found(arg_name)){
       Ctrl::getInstance()->displayErrorMessage(901);
       return;

--- a/src/base_cmdline.cpp
+++ b/src/base_cmdline.cpp
@@ -89,13 +89,33 @@ void MainApp::evalCmdLine(){
     }
     return;
   }
-  // check if all required arguments are available
+  
+  // Check if all required arguments are available
+  std::vector<std::string> missing_args;
+  
   for (const std::string& arg_name : s_required_args){
     if (!parser.Found(arg_name)){
-      Ctrl::getInstance()->displayErrorMessage(901);
-      return;
+      missing_args.push_back(arg_name);
     }
   }
+  
+  switch (missing_args.size()){
+    case (0):
+      break;
+    case (1):
+      Ctrl::getInstance()->displayErrorMessage(911, missing_args);
+      return;
+    case (2):
+      Ctrl::getInstance()->displayErrorMessage(912, missing_args);
+      return;
+    case (3):
+      Ctrl::getInstance()->displayErrorMessage(913, missing_args);
+      return;
+    default:
+      Ctrl::getInstance()->displayErrorMessage(914, missing_args);
+      return;
+  }
+  // All required arguments are available
 
   Ctrl::getInstance()->hush(parser.Found("q"));
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -612,17 +612,16 @@ static const std::map<int, std::string> s_error_codes = {
   {903, "Elements file import failed. Calculation aborted."}
 };
 
+// Either print error message to GUI or command line
 void Ctrl::displayErrorMessage(const int error_code){
+  std::string msg = getErrorMessage(error_code);
+
   if (_to_gui){
-    s_gui->extOpenErrorDialog(error_code, getErrorMessage(error_code));
+    s_gui->extOpenErrorDialog(error_code, msg);
   }
   else{
-    printErrorMessage(error_code);
+    std::cout << error_code << ": " << msg << std::endl;
   }
-}
-
-void Ctrl::printErrorMessage(const int error_code){
-  std::cout << error_code << ": " << getErrorMessage(error_code) << std::endl;
 }
 
 std::string Ctrl::getErrorMessage(const int error_code){

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -607,19 +607,33 @@ static const std::map<int, std::string> s_error_codes = {
   {303, "An unidentified issue has been encountered while writing the surface map."},
   // 9xx: Issues with command line arguments
   {900, "Command line interface failed!"},
-  {901, "At least one required command line argument missing."},
   {902, "Invalid output display option. At least one parameter belonging to '-o' is invalid and will be ignored."},
-  {903, "Elements file import failed. Calculation aborted."}
+  {903, "Elements file import failed. Calculation aborted."},
+  // 9xx: Required command line arguments missing
+  {910, "Unexpected error. More than three required command line arguments appear to be missing."},
+  {911, "One required command line argument missing. Please provide --%s"},
+  {912, "Two required command line arguments missing. Please provide --%s and --%s"},
+  {913, "Three required command line arguments missing. Please provide --%s, --%s, and --%s"}
 };
 
-// Either print error message to GUI or command line
-void Ctrl::displayErrorMessage(const int error_code){
+// Print error message either to GUI or console
+void Ctrl::displayErrorMessage(const int error_code, const std::vector<std::string>& str_fill){
   std::string msg = getErrorMessage(error_code);
 
+  // Substitute place holders
+  size_t i = 0;
+  while (msg.find("%s") != std::string::npos){
+    assert(str_fill.size() > i);
+    msg.replace(msg.find("%s"), 2, str_fill[i]);
+    ++i;
+  }
+
   if (_to_gui){
+    // Print to GUI
     s_gui->extOpenErrorDialog(error_code, msg);
   }
   else{
+    // Print to console
     std::cout << error_code << ": " << msg << std::endl;
   }
 }


### PR DESCRIPTION
Improves error messages displayed when using the CLI, in case there are any required command line arguments missing. Previously, the missing arguments would not be explicitly named. With this change, a list of missing command line arguments are returned as part of the error message.

Resolves: #118 