### PR TITLE
fix duplicate atoms at the border

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -483,7 +483,7 @@ void Model::moveAtomsInsideCell(){
       std::get<2>(_processed_atom_coordinates[n]) += _cart_matrix[2][1];
       std::get<1>(_processed_atom_coordinates[n]) += _cart_matrix[2][0];
     }
-    while(std::get<3>(_processed_atom_coordinates[n]) > _cart_matrix[2][2]){
+    while(std::get<3>(_processed_atom_coordinates[n]) >= _cart_matrix[2][2]){
       std::get<3>(_processed_atom_coordinates[n]) -= _cart_matrix[2][2];
       std::get<2>(_processed_atom_coordinates[n]) -= _cart_matrix[2][1];
       std::get<1>(_processed_atom_coordinates[n]) -= _cart_matrix[2][0];
@@ -492,14 +492,14 @@ void Model::moveAtomsInsideCell(){
       std::get<2>(_processed_atom_coordinates[n]) += _cart_matrix[1][1];
       std::get<1>(_processed_atom_coordinates[n]) += _cart_matrix[1][0];
     }
-    while(std::get<2>(_processed_atom_coordinates[n]) > _cart_matrix[1][1]){
+    while(std::get<2>(_processed_atom_coordinates[n]) >= _cart_matrix[1][1]){
       std::get<2>(_processed_atom_coordinates[n]) -= _cart_matrix[1][1];
       std::get<1>(_processed_atom_coordinates[n]) -= _cart_matrix[1][0];
     }
     while(std::get<1>(_processed_atom_coordinates[n]) < 0){
       std::get<1>(_processed_atom_coordinates[n]) += _cart_matrix[0][0];
     }
-    while(std::get<1>(_processed_atom_coordinates[n]) > _cart_matrix[0][0]){
+    while(std::get<1>(_processed_atom_coordinates[n]) >= _cart_matrix[0][0]){
       std::get<1>(_processed_atom_coordinates[n]) -= _cart_matrix[0][0];
     }
   }


### PR DESCRIPTION
In rare cases, atoms are exactly on the unit cell border. The previous operations to move atoms inside the unit cell led to some duplicate atoms on opposite borders of the orthogonalized unit cell leading to wrong chemical formula and unit cell mass.