### PR TITLE
Install MoloVol directly to server

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -16,7 +16,8 @@ COPY include/ include/
 COPY LICENSE ./
 COPY README.md ./
 COPY inputfile/ inputfile/
-RUN cmake . -DCMAKE_BUILD_TYPE=RELEASE && make
+RUN cmake . -DCMAKE_BUILD_TYPE=RELEASE -DMOLOVOL_ABS_RESOURCE_PATH=ON && make
+RUN cpack -G DEB && dpkg -i MoloVol_*.deb
 WORKDIR /
 
 # add flask webserver

--- a/launch_headless.sh
+++ b/launch_headless.sh
@@ -2,4 +2,4 @@
 # This script launches the headless version of the application by creating fake display so that wxwidgets is happy.
 export DISPLAY=:1.0
 Xvfb :1 -screen 0 1024x768x16 &> xvfb.log  &
-./build/molovol "$@"
+molovol "$@"

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -316,9 +316,9 @@ def io():
                 args.append(structure_path)
 
             # read elements file
-            elements_path = "./inputfile/elements.txt"
+            elements_path = "/usr/share/molovol/elements.txt"
             args.append("-fe")
-            args.append(elements_path)
+            args.append(elements_path) # May not even be necessary
 
             # we only print it out in the end, so we can put it to quiet
             args.append("-q")

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -21,9 +21,15 @@ app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 if not os.path.exists(UPLOAD_FOLDER):
     os.makedirs(UPLOAD_FOLDER)
 
-out = None
 log_dir = "./logs/"
 export_dir = "./export/"
+
+if not os.path.exists(log_dir):
+    os.makedirs(log_dir)
+if not os.path.exists(export_dir):
+    os.makedirs(export_dir)
+
+out = None
 
 # Cross-Origin Resource Sharing
 cors = CORS(app, resources={r"/api/*": {"origins": "http://localhost:4000"}})


### PR DESCRIPTION
Instead of building the executable in a build directory and running it
directly from there, it is much safer to build a deb file for
installation and use it to install MoloVol to the system. This makes
MoloVol accessible directly through the command "molovol" by adding the
executable to the PATH. Hence launch_headless.sh can directly call the
command instead of running the executable from the build folder.

The instructions for installation have been added to the Dockerfile.

The benefit of this is that resource files are installed on a system
directory instead of in a local directory. This makes the setup less
susceptible to subtle changes, such as changing the working directory,
binary directory, or resource directory.

This change required an adjustment in app.py, so that the system
elements file is accessed instead of the local elements file.